### PR TITLE
remove transitions and add manual mouse easing

### DIFF
--- a/intense.js
+++ b/intense.js
@@ -20,7 +20,9 @@ window.cancelRequestAnimFrame = ( function() {
 var Intense = (function() {
 
     'use strict';
-    var mouse = { x:0, y:0 };
+    // Track both the current and destination mouse coordinates
+    // Destination coordinates are non-eased actual mouse coordinates
+    var mouse = { xCurr:0, yCurr:0, xDest: 0, yDest: 0 };
     var mouseEvent;
 
     var horizontalOrientation = true;
@@ -163,15 +165,7 @@ var Intense = (function() {
       container.appendChild( target );
       applyProperties( container, containerProperties );
 
-      /*
-       *  Image
-       *  -- No easing for firefox, since there are no smooth transisions when the transform
-       *  -- property keeps on changing... it looks jagged. Seriously, give it a try!
-       */
       var imageProperties = {
-        'webkitTransition': '-webkit-transform 800ms cubic-bezier( 0, 0, .26, 1 )',
-        // 'MozTransition': '-moz-transform 800ms cubic-bezier( 0, 0, .26, 1 )',
-        'msTransition': '-ms-transform 800ms cubic-bezier( 0, 0, .26, 1 )',
         'cursor': 'url( "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo3Q0IyNDI3M0FFMkYxMUUzOEQzQUQ5NTMxMDAwQjJGRCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo3Q0IyNDI3NEFFMkYxMUUzOEQzQUQ5NTMxMDAwQjJGRCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjdDQjI0MjcxQUUyRjExRTM4RDNBRDk1MzEwMDBCMkZEIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjdDQjI0MjcyQUUyRjExRTM4RDNBRDk1MzEwMDBCMkZEIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+soZ1WgAABp5JREFUeNrcWn9MlVUY/u4dogIapV0gQ0SUO4WAXdT8B5ULc6uFgK3MLFxzFrQFZMtaed0oKTPj1x8EbbZZK5fNCdLWcvxQ+EOHyAQlBgiIVFxAJuUF7YrQ81zOtU+8F+Pe78K1d3s5537f+fE8nPec7z3vOSpJIRkbGwtEEgtdBdVCl0AXQr2hKqgJeg16BdoCrYNWqVSqbif7VQT8YqgB2jTmuDSJNoIcJUJVOVg5EsmH0Oehaj4bGRkZ6uvra2xvb29oamrqbGxs7K2vrx/s7Oy8yffBwcFzdTqdb0REhF9YWFhwSEhIpEajifDw8PAWzY5Cj0GzMUoNUx0R1RQJaJAcgKaw7ujo6O2urq7qysrKioyMjHNDQ0OjU2nP29tbnZ+fv1qv18cFBQWtU6vVs9gN9BvobhDqU5wIKryA5CuoLwj83dzc/NOePXuOlpSUXFNijiUlJS3ct2/fiytWrHgOhGbj0SD0dZD5UREiKOiJJA+axt9Go7F2165deUeOHOmVXCBbt271y8nJyfD3939aPCqCZoCQ2WEiKOQj7HYjzejUqVNFcXFxJdI0SEVFRdKGDRtShbmd5HwEGZM9IupJSHiJBjaazebr2dnZmdNFgsK+2Cf7JgZiEZhsimoSc/oZqh8eHjamp6fvPnTo0O/SDMiOHTsWFRQUHPDy8vLnQEGflZvZpKaFl4WcE7du3epPTU19+/Dhwz3SDMr27dsDioqKcufMmfM45wyIpD3QtPBiC0lgTowcPHgwa6ZJUIiBWIgJP1OB8aVJTQsFnkDSxCUWk60gPj6+VHIjKS8vT8TcSRdLcxhG5g+bpoWH3yF5ube3tw7L33uSGwqW/8/8/Pzoz30PItvuMy080HEZx/CZDQZDgeSmQmzESKwC870jgodcWhPhJx0LDw8vlNxYLl269Cb8Nfp5NP2kuyMiPM8EfvTodkhuLsQoJn4C/VG5ab3CfHd3d41SvpMrhRiBtVrgf01OZBv/nIRID4nIsG6xzBGxs7vK/YSvr2/SVF3xiYL55bVgwYJZp0+f/nOycuvXr38E+xczvOibjvTDLcDg4OBx7GfoD4ZwRPR8gUYbnCUBF3wuHMtPy8rKcmJjY33tleM7lqmpqdnPOo70RazAfNHapFrssaWOjo6Lzg43vj2zPT09febNm7ektLT0C1tk+IzvWIZlWcfR/oC5UWSjSCSUudbW1qvOEqmqqhrcvHnzOzdu3Lhii4ycBMuwLOs42t/ly5etmLUkEsJcbW3tbwq5ETbJ2CLBss70dfbsWSvmpZzsnJTzo6KiEhoaGoaVWlXkwE0mkyXk4+PjE6gUCUpMTMz86urq48gOkIjFWYHfEqf0EkkyJ06cyCMB/iah5OTkTCVIUDQajQf8wl+QNaune/2/c+eOS9olkb+YiYyM9FJ6NGhaHA2OBJV5e6uZI6LVaq2YTSTSz9zatWsfc8X84JzYtGlTJtXeauaorFy5cr7IXieRdubWrFnzpCtIJCYmWpZYKvNKksE/34q5g0RamQsNDV3sKhLy74ySZJYtW2bF3EIidZaFeOnSp5wl0t/fb4aYbJGwRYZlWcfR/mSYL8idRhOcxuTpdBoHBgZuY5Pk0LfrPqdRnE8080Fubm60Aru34QeRoLCMoyQoxCpItFnnCIVBB2kj5GHZj8iw/iDfWJHIaGBgYAyj4u5OghiBdZ00fqby9V0iMK8rSMoYMGZo392JECOwehAztHNipPFjxiGw0UnYuXPnInclQWzEKI0fCH1kL9JoCdAZjcZzAQEB77sjkZ6env3YjK22G6AT8i7DkSzI8KS7kSAmQWJQYL3HabwrjKVK4mQKX9w0g8EQ6i4k9u7dqyUm8TNNYJVsmpbMxL5EkuouxwopKSn+xcXFeeJYoRgkUmVYJyXirgc9ldBnbB302NxYiYJcGc6wgcLCwvysrCztTJgT+xYkzhCTvUPR//9hqBgZkxiZYjao1+vf4vLH4XalKbEP9iVIFIuRME2K9b92MOHCAEOdZS66MJAAAp5iiX0DBI4+ANfUiIhKvMLxOfRVSXaFA2ZQnpmZWefIFY68vLxVMNf4CVc4vuV3wiVXOCZUjkLygXTvpRoTL9Uw9NrS0tJVX1/fc/78+ettbW2WIPXy5cvnRkdHP6rT6QK0Wm0QNkXhGo0mUrjikvTvpZpPQODCFLA4bw6ya06/OnHNqXnGrjnZIyWNXzyjC0GPYIk0fvHM+h+XXzxjnOCcNH7x7KqT/VrSfwQYAOAcX9HTDttYAAAAAElFTkSuQmCC" ) 25 25, auto'
       }
       applyProperties( target, imageProperties );
@@ -235,8 +229,8 @@ var Intense = (function() {
 
       setDimensions();
 
-      mouse.x = window.innerWidth / 2;
-      mouse.y = window.innerHeight / 2;
+      mouse.xCurr = mouse.xDest = window.innerWidth / 2;
+      mouse.yCurr = mouse.yDest = window.innerHeight / 2;
       
       document.body.appendChild( container );
       setTimeout( function() {
@@ -303,43 +297,44 @@ var Intense = (function() {
   
     function onMouseMove( event ) {
 
-      mouse.x = event.clientX;
-      mouse.y = event.clientY;
+      mouse.xDest = event.clientX;
+      mouse.yDest = event.clientY;
     }
 
     function onTouchMove( event ) {
 
-      mouse.x = event.touches[0].clientX;
-      mouse.y = event.touches[0].clientY;
+      mouse.xDest = event.touches[0].clientX;
+      mouse.yDest = event.touches[0].clientY;
     }
   
     function positionTarget() {
 
+      mouse.xCurr += ( mouse.xDest - mouse.xCurr ) * 0.05;
+      mouse.yCurr += ( mouse.yDest - mouse.yCurr ) * 0.05;
+
       if ( horizontalOrientation === true ) {
 
         // HORIZONTAL SCANNING
-        currentPosition += (mouse.x - currentPosition);
-        if( mouse.x !== lastPosition  ) {
-
+        currentPosition += (mouse.xCurr - currentPosition);
+        if( mouse.xCurr !== lastPosition  ) {
           var position = parseFloat(currentPosition / containerDimensions.w );
-          position = Math.ceil(overflowArea.x * position);
+          position = overflowArea.x * position;
           target.style[ 'webkitTransform' ] = 'translate3d(' + position + 'px, 0px, 0px)';
           target.style[ 'MozTransform' ] = 'translate3d(' + position + 'px, 0px, 0px)';
           target.style[ 'msTransform' ] = 'translate3d(' + position + 'px, 0px, 0px)';
-          lastPosition = mouse.x;
-
+          lastPosition = mouse.xCurr;
         }
       } else if ( horizontalOrientation === false ) {
 
         // VERTICAL SCANNING
-        currentPosition += (mouse.y - currentPosition);
-        if( mouse.y !== lastPosition  ) {
+        currentPosition += (mouse.yCurr - currentPosition);
+        if( mouse.yCurr !== lastPosition  ) {
           var position = parseFloat(currentPosition / containerDimensions.h );
-          position = Math.ceil(overflowArea.y * position);
+          position = overflowArea.y * position;
           target.style[ 'webkitTransform' ] = 'translate3d( 0px, ' + position + 'px, 0px)';
           target.style[ 'MozTransform' ] = 'translate3d( 0px, ' + position + 'px, 0px)';
           target.style[ 'msTransform' ] = 'translate3d( 0px, ' + position + 'px, 0px)';
-          lastPosition = mouse.y;
+          lastPosition = mouse.yCurr;
         }
       }
     }


### PR DESCRIPTION
This commit handles the issue of transitions being choppy in certain browsers. Includes:
1. Removing transforms
2. Tracking current and destination mouse coordinates
3. Easing mouse coordinates to manual create a transition
4. Allowing subpixel values (the end of the animation can be slightly choppy otherwise)
