### PR TITLE
Added a candidate package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "intense-images",
+  "version": "1.0.0",
+  "description": "A simple library to view large images up close using simple mouse interaction, and the full screen.",
+  "main": "intense.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tholman/intense-images.git"
+  },
+  "keywords": [
+    "web",
+    "front-end",
+    "images"
+  ],
+  "author": "Tim Holman <timothy.w.holman@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tholman/intense-images/issues"
+  },
+  "homepage": "https://github.com/tholman/intense-images#readme"
+}


### PR DESCRIPTION
Based on our chat recently, it is obvious that you want to skip the spinning rims on the build system and keep things simple, and I agree :)

This commit includes a simple package.json which  allows you to push the project to npm so others can easily include it. It doesn't handle asset building at all, since it is generally up to the consumer of front-end modules to sort out their packaging and minification needs.

